### PR TITLE
Issue #SB-27305 fix: Contributor populate and text fix

### DIFF
--- a/src/app/client/src/app/modules/program/components/create-program/create-program.component.html
+++ b/src/app/client/src/app/modules/program/components/create-program/create-program.component.html
@@ -87,7 +87,7 @@
 											</div>
 										</div>
                     					<div class="sb-radio-btn-checkbox sb-radio-btn-primary mr-10">
-											<div [ngClass]="(editPublished) ? 'disabled field':''"> 
+											<div [ngClass]="(editPublished) ? 'disabled field':''">
 												<input type="radio" formControlName="type" id="type_restricted" value="restricted" appTelemetryInteract [telemetryInteractEdata]="getTelemetryInteractEdata('from_a_selected_set_of_contributors', configService.telemetryLabels.eventType.select, configService.telemetryLabels.eventSubtype.radioButton,telemetryPageId)"
 												[telemetryInteractObject]="telemetryInteractObject"
 												[telemetryInteractCdata]="telemetryInteractCdata"
@@ -101,7 +101,7 @@
 													class="sb-color-primary">{{resource?.frmelmnts?.lbl?.selectToContributor}}</span>
 												<div *ngIf="selectedContributorsCnt > 0" class="px-0 d-inline-block">
 													<em><span>{{selectedContributorsCnt}}</span>&nbsp;
-														<span>{{resource?.frmelmnts?.lbl?.createProject?.contributor?.added}}</span></em>
+														<span>{{resource?.frmelmnts?.lbl?.selectContributors?.contributor?.added}}</span></em>
 													<div class="sb-dock-icon-tooltip d-inline-block">
 														<i class="icon edit sb-color-primary ui px-5"
 															data-tooltip="Modify"></i>

--- a/src/app/client/src/app/modules/program/components/create-program/create-program.component.ts
+++ b/src/app/client/src/app/modules/program/components/create-program/create-program.component.ts
@@ -179,6 +179,10 @@ export class CreateProgramComponent implements OnInit, AfterViewInit {
         this.initializeProjectTargetTypeForm();
         this.openProjectTargetTypeModal = true;
       }
+
+      if (!_.isEmpty(_.get(this.programDetails, 'config.contributors'))) {
+        this.setPreSelectedContributors(_.get(this.programDetails, 'config.contributors'));
+      }
     }, error => {
       const errInfo = {
         errorMsg:  'Fetching program details failed',
@@ -1767,7 +1771,7 @@ showTexbooklist(showTextBookSelector = true) {
     this.getCollectionCategoryDefinition();
     this.blueprintFormConfig = this.blueprintTemplate.properties;
   }
-  
+
   getFormattedData(formValue, fieldGroups) {
     // tslint:disable-next-line:only-arrow-functions
     const truthyformValue = _.pickBy(formValue, function(value, key) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27305" title="SB-27305" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-27305</a>  Contributed added text is missing post selecting the contributors while creating the project.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Angular 8, Nodejs 12.16.1
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

